### PR TITLE
Add full name and profile picture to user profile

### DIFF
--- a/server/src/db/migrations/20240521161314_pfp.ts
+++ b/server/src/db/migrations/20240521161314_pfp.ts
@@ -1,0 +1,15 @@
+import type { Knex } from "knex";
+
+export const up = (knex: Knex) => {
+  return knex.schema.alterTable("users", (table) => {
+    table.string("profile_image", 255).nullable().defaultTo(null);
+    table.string("full_name", 255).notNullable().defaultTo("");
+  });
+};
+
+export const down = (knex: Knex) => {
+  return knex.schema.alterTable("users", (table) => {
+    table.dropColumn("profile_image");
+    table.dropColumn("full_name");
+  });
+};

--- a/server/src/models/Post.ts
+++ b/server/src/models/Post.ts
@@ -21,7 +21,7 @@ const posts = model(
     user_id: z.number(),
     created_at: z.date().optional(),
     updated_at: z.date().optional(),
-    closed: z.boolean(),
+    closed: z.boolean().optional(),
   })
 );
 
@@ -83,10 +83,11 @@ export const list = (
     if (q) { where.push(`lower(title) LIKE lower(?)`); buf.push(`%${q}%`); }
     if (user && user > 0) { where.push(`user_id = ?`); buf.push(user); }
     if (!closed) { where.push(`closed = false`); }
-    if (where.length) { query += ` WHERE ${where.join("AND")}`; }
+
+    if (where.length) { query += ` WHERE ${where.join(" AND ")}`; }
+    query += ` ORDER BY created_at ${order === "asc" ? "ASC" : "DESC"}`;
     if (limit && limit > 0) { query += ` LIMIT ?`; buf.push(limit); }
     if (offset && offset > 0) { query += ` OFFSET ?`; buf.push(offset); }
-    query += ` ORDER BY created_at ${order === "asc" ? "ASC" : "DESC"}`;
   }
 
   return posts.queryMany(query, buf);

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import bcrypt from "bcrypt";
 import model, { RowType } from "../utils/model";
+import { processImage } from "../utils/image";
 
 export type User = RowType<typeof users>;
 
@@ -11,8 +12,10 @@ const users = model(
     id: z.number().optional(),
     username: z.string(),
     password: z.string(),
+    full_name: z.string().optional(),
     created_at: z.date().optional(),
     updated_at: z.date().optional(),
+    profile_image: z.string().nullish(),
   }),
   (data) => {
     // @ts-expect-error 2339
@@ -23,6 +26,9 @@ const users = model(
   }
 );
 
+const hashPassword = (plaintext: string) =>
+  bcrypt.hash(plaintext, 10).catch((err) => console.log(err.message));
+
 export const list = () => users.list();
 
 export const find = (id: number) => users.findBy("id", id);
@@ -30,13 +36,42 @@ export const find = (id: number) => users.findBy("id", id);
 export const findByUsername = (username: string) => users.findBy("username", username);
 
 export const create = async (username: string, password: string) => {
-  const hashed = await bcrypt.hash(password, 10).catch((err) => console.log(err.message));
+  const hashed = await hashPassword(password);
   if (!hashed) {
     return;
   }
   return await users.create({ username, password: hashed });
 };
 
-export const update = (user: User, username: string) => users.update(user, { username });
+export const update = async (
+  self: User,
+  username?: string,
+  password?: string,
+  full_name?: string,
+  profile_image?: string
+) => {
+  const obj: Parameters<typeof users.update>[1] = {};
+  if (profile_image !== undefined) {
+    obj.profile_image = await processImage(profile_image);
+  }
+
+  if (password !== undefined) {
+    const next = await hashPassword(password);
+    if (!next) {
+      return;
+    }
+    obj.password = next;
+  }
+
+  if (username !== undefined) {
+    obj.username = username;
+  }
+
+  if (full_name !== undefined) {
+    obj.full_name = full_name;
+  }
+
+  return await users.update(self, obj);
+};
 
 export const deleteAll = () => users.deleteAll();

--- a/server/src/routers/auth.ts
+++ b/server/src/routers/auth.ts
@@ -1,8 +1,7 @@
 import express from "express";
-import bcrypt from "bcrypt";
 import { z } from "zod";
 import { Event, User } from "../models";
-import { checkAuthentication } from "../utils/auth";
+import { checkAuthentication, isValidPassword } from "../utils/auth";
 
 const authRouter: express.Router = express.Router();
 
@@ -10,10 +9,6 @@ const userLogin = z.object({
   username: z.string().max(255),
   password: z.string().max(255),
 });
-
-/** Check if a given password matches a given hash, returns a bool, or undefined if error */
-const isValidPassword = async (plaintext: string, hash: string) =>
-  bcrypt.compare(plaintext, hash).catch((err) => console.error(err.message));
 
 // This controller returns 401 if the client is NOT logged in (doesn't have a cookie)
 // or returns the user based on the userId stored on the client's cookie
@@ -38,7 +33,7 @@ authRouter.post("/login", async (req, res) => {
   const user = await User.findByUsername(body.data.username);
   if (!user) {
     return res.sendStatus(404);
-  } else if (!await isValidPassword(body.data.password, user.password)) {
+  } else if (!(await isValidPassword(body.data.password, user.password))) {
     return res.sendStatus(401);
   }
 

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -1,4 +1,9 @@
 import { NextFunction, Request, Response } from "express";
+import bcrypt from "bcrypt";
+
+/** Check if a given password matches a given hash, returns a bool, or undefined if error */
+export const isValidPassword = (plaintext: string, hash: string) =>
+  bcrypt.compare(plaintext, hash).catch((err) => console.error(err.message));
 
 // Is the user logged in? Not specific user, just ANY user
 export const checkAuthentication = (req: Request, res: Response, next: NextFunction) => {

--- a/server/src/utils/model.ts
+++ b/server/src/utils/model.ts
@@ -97,6 +97,10 @@ export class Model<
   async update(self: Data<S>, data: Partial<Output>) {
     // data keys are server controlled, sql injection doesn't matter here
     const values = Object.values(data);
+    if (!values.length) {
+      return self;
+    }
+
     const keys = Object.keys(data).map((key) => `${key}=?`);
     values.push(self[this.pkey]); // cant be undefined
     return this.queryOne(


### PR DESCRIPTION
- Add full_name and profile_picture to the user profile. These start out as "" and NULL respectively, but can be changed with a PATCH request to /users/:id
- Allow all profile data, including the user's password, to be changed. Changing the password also requires providing the original password.
- Fix bugs in the query generated when searching for a post